### PR TITLE
find_timezone Fix

### DIFF
--- a/lib/campfire_export.rb
+++ b/lib/campfire_export.rb
@@ -143,10 +143,9 @@ module CampfireExport
     end
 
     def find_timezone
-      settings = Nokogiri::HTML get('/account/settings').body
-      selected_zone = settings.css('select[id="account_time_zone_id"] ' +
-                                   '> option[selected="selected"]')
-      Account.timezone = find_tzinfo(selected_zone.attribute("value").text)
+      settings = Nokogiri::XML get('/account.xml').body
+      selected_zone = settings.css('time-zone')
+      Account.timezone = find_tzinfo(selected_zone.text)
     end
 
     def rooms


### PR DESCRIPTION
I attempted to use campfire_exporter from rubygems and got this error:

`NoMethodError: undefined method `attribute' for nil:NilClass`

I traced this down to an error fetching the timezone. The find_timezone method has now been modified to use the Campfire API's account.xml to retrieve the timezone.
