### PR TITLE
Gemspec now reflects dependencies required to run campfire_exporter

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ Also, thanks much for all the help, comments and contributions:
 * [Brad Greenlee](https://github.com/bgreenlee)
 * [Andre Arko](https://github.com/indirect)
 * [Brian Donovan](https://github.com/eventualbuddha)
+* [Andrew Wong](https://github.com/andrewwong1221)
 
 As mentioned above, some of the work on this was done by other people. The
 Gist I forked had contributions from:

--- a/Rakefile
+++ b/Rakefile
@@ -1,3 +1,4 @@
+require 'rubygems'
 require 'bundler'
 Bundler::GemHelper.install_tasks
 

--- a/campfire_export.gemspec
+++ b/campfire_export.gemspec
@@ -19,9 +19,9 @@ Gem::Specification.new do |s|
   s.add_development_dependency "bundler",  "~> 1.0.15"
   s.add_development_dependency "fuubar",   "~> 0.0.5"
   s.add_development_dependency "rspec",    "~> 2.6.0"
-  s.add_development_dependency "tzinfo",   "~> 0.3.29"
-  s.add_development_dependency "httparty", "~> 0.7.8"
-  s.add_development_dependency "nokogiri", "~> 1.4.5"
+  s.add_dependency "tzinfo",   "~> 0.3.29"
+  s.add_dependency "httparty", "~> 0.7.8"
+  s.add_dependency "nokogiri", "~> 1.4.5"
 
   s.files         = `git ls-files`.split("\n")
   s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")

--- a/lib/campfire_export.rb
+++ b/lib/campfire_export.rb
@@ -143,10 +143,9 @@ module CampfireExport
     end
 
     def find_timezone
-      settings = Nokogiri::HTML get('/account/settings').body
-      selected_zone = settings.css('select[id="account_time_zone_id"] ' +
-                                   '> option[selected="selected"]')
-      Account.timezone = find_tzinfo(selected_zone.attribute("value").text)
+      settings = Nokogiri::XML get('/account.xml').body
+      selected_zone = settings.css('time-zone')
+      Account.timezone = find_tzinfo(selected_zone.text)
     end
 
     def rooms

--- a/lib/campfire_export/version.rb
+++ b/lib/campfire_export/version.rb
@@ -1,3 +1,3 @@
 module CampfireExport
-  VERSION = "0.1.2"
+  VERSION = "0.2.0"
 end

--- a/spec/campfire_export/account_spec.rb
+++ b/spec/campfire_export/account_spec.rb
@@ -8,13 +8,23 @@ module CampfireExport
       @api_token = "test-apikey"
       @account   = Account.new(@subdomain, @api_token)
       
-      @good_timezone = '<select id="account_time_zone_id">' +
-          '<option selected="selected" value="America/Los_Angeles">' +
-          '</option></select>'
+      @good_timezone = '<?xml version="1.0" encoding="UTF-8"?>' +
+					   '<account>' +
+					   '  <time-zone>America/Los_Angeles</time-zone>' +
+					   '  <owner-id type="integer">99999</owner-id>' +
+					   '  <created-at type="datetime">2010-01-31T18:30:18Z</created-at>' +
+					   '  <storage type="integer">9999999</storage>' +
+					   '  <plan>basic</plan>' +
+					   '  <updated-at type="datetime">2010-01-31T18:31:55Z</updated-at>' +
+					   '  <subdomain>example</subdomain>' +
+					   '  <name>Example</name>' +
+					   '  <id type="integer">999999</id>' +
+					   '</account>'
+
       @bad_timezone  = @good_timezone.gsub('America/Los_Angeles', 
                                            'No Such Timezone')
-      @timezone_html = stub("timezone HTML block")
-      @timezone_html.stub(:body).and_return(@good_timezone)
+      @account_xml = stub("Account XML")
+      @account_xml.stub(:body).and_return(@good_timezone)
     end
       
     context "when it is created" do
@@ -27,23 +37,23 @@ module CampfireExport
     
     context "when timezone is loaded" do
       it "determines the user's timezone" do
-        @account.should_receive(:get).with("/account/settings"
-          ).and_return(@timezone_html)
+        @account.should_receive(:get).with("/account.xml"
+          ).and_return(@account_xml)
         @account.find_timezone
         Account.timezone.to_s.should == "America - Los Angeles"        
       end
       
       it "raises an error if it gets a bad time zone identifier" do
-        @timezone_html.stub(:body).and_return(@bad_timezone)
-        @account.stub(:get).with("/account/settings"
-          ).and_return(@timezone_html)
+        @account_xml.stub(:body).and_return(@bad_timezone)
+        @account.stub(:get).with("/account.xml"
+          ).and_return(@account_xml)
         expect {
           @account.find_timezone
         }.to raise_error(TZInfo::InvalidTimezoneIdentifier)
       end
       
       it "raises an error if it can't get the account settings at all" do
-        @account.stub(:get).with("/account/settings"
+        @account.stub(:get).with("/account.xml"
           ).and_raise(CampfireExport::Exception.new("/account/settings", 
             "Not Found", 404))
         expect {


### PR DESCRIPTION
I noticed that there were runtime dependencies missing when installing campfire_exporter for the first time.  This commit should resolve that issue.
