### PR TITLE
Skip <message> elements within <tweet> elements.

### DIFF
--- a/lib/campfire_export.rb
+++ b/lib/campfire_export.rb
@@ -217,7 +217,7 @@ module CampfireExport
       rescue Exception => e
         log(:error, "transcript export for #{export_dir} failed", e)
       else
-        @messages = xml.css('message').map do |message|
+        @messages = xml.css('messages > message').map do |message|
           CampfireExport::Message.new(message, room, date)
         end
       


### PR DESCRIPTION
campfire_export script abort if transcripts xml contains TweetMessage type messages like below:

```
<message>
  <created-at type="datetime">2011-09-14T08:55:32Z</created-at>
  <id type="integer">409900764</id>
  <room-id type="integer">000001</room-id>
  <user-id type="integer">000001</user-id>
  <body>Twitter is now available in four new languages: Danish, Finnish, Norwegian and Polish. -- @twitter, https://twitter.com/twitter/status/149299492917747712</body>
  <type>TweetMessage</type>
  <tweet>
    <id>149299492917747712</id>
    <message>Twitter is now available in four new languages: Danish, Finnish, Norwegian and Polish.</message>
    <author_username>twitter</author_username>
    <author_avatar_url>https://twimg0-a.akamaihd.net/profile_images/1124040897/at-twitter_normal.png</author_avatar_url>
  </tweet>
</message>
```

I fixed this behavior.
