### PR TITLE
Export list of users and rooms. Take config file as arg. Move errors log.

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,10 @@ directory using this template:
     # Your Campfire API token (see "My Info" on your Campfire site).
     api_token:  abababababababababababababababababababab
 
+    # OPTIONAL: Export base dir - location to store the export files.
+    # Uncomment to set.
+    #export_basedir: ~/campfire_export/
+
     # OPTIONAL: Export start date - the first transcript you want exported.
     # Uncomment to set. Defaults to the date each room was created.
     #start_date: 2010/1/1
@@ -67,13 +71,14 @@ Campfire room was created, until the date of the last message in that room.
 ## Exporting ##
 
 Just run `campfire_export` and your transcripts will be exported into a
-`campfire` directory in the current directory, with subdirectories for each
-site/room/year/month/day. In those directories, any uploaded files will be
-saved with their original filenames, in a directory named for the upload ID
-(since transcripts often have the same filename uploaded multiple times, e.g.
-`Picture 1.png`). (Note that rooms and uploaded files may have odd filenames
--- for instance, spaces in the file/directory names.) Errors that happen
-trying to export will be logged to `campfire/export_errors.txt`.
+`campfire` directory in the current directory (or your `export_basedir`
+setting), with subdirectories for each site/room/year/month/day. In those
+directories, any uploaded files will be saved with their original filenames,
+in a directory named for the upload ID (since transcripts often have the same
+filename uploaded multiple times, e.g. `Picture 1.png`). (Note that rooms and
+uploaded files may have odd filenames -- for instance, spaces in the
+file/directory names.) Errors that happen trying to export will be logged to
+`campfire/export_errors.txt`.
 
 The Gist I forked had a plaintext transcript export, which I've kept in as
 `transcript.txt` in each directory. However, the original XML and HTML are now

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ in a directory named for the upload ID (since transcripts often have the same
 filename uploaded multiple times, e.g. `Picture 1.png`). (Note that rooms and
 uploaded files may have odd filenames -- for instance, spaces in the
 file/directory names.) Errors that happen trying to export will be logged to
-`campfire/export_errors.txt`.
+`campfire/<subdomain>/export_errors.txt`.
 
 The Gist I forked had a plaintext transcript export, which I've kept in as
 `transcript.txt` in each directory. However, the original XML and HTML are now

--- a/bin/campfire_export
+++ b/bin/campfire_export
@@ -57,8 +57,9 @@ begin
   account = CampfireExport::Account.new(config['subdomain'], 
                                         config['api_token'])
   account.find_timezone
+  account.export_rooms_list
   account.rooms.each do |room|
-    room.export(config_date(config, 'start_date'), 
+    room.export(config_date(config, 'start_date'),
                 config_date(config, 'end_date'))
   end
 rescue => e

--- a/bin/campfire_export
+++ b/bin/campfire_export
@@ -42,7 +42,8 @@ def ensure_config_for(config, key, prompt)
 end
 
 config = {}
-config_file = ARGV[0] or File.join(ENV['HOME'], '.campfire_export.yaml')
+config_file = File.join(ENV['HOME'], '.campfire_export.yaml')
+config_file = ARGV[0] if ARGV[0]
 
 if File.exists?(config_file) and File.readable?(config_file)
   config = YAML.load_file(config_file)  

--- a/bin/campfire_export
+++ b/bin/campfire_export
@@ -57,11 +57,12 @@ begin
   account = CampfireExport::Account.new(config['subdomain'], 
                                         config['api_token'])
   account.find_timezone
-  account.export_rooms_list
   account.rooms.each do |room|
     room.export(config_date(config, 'start_date'),
                 config_date(config, 'end_date'))
   end
+  account.export_rooms_list
+  account.export_users_list
 rescue => e
   puts "Unable to export account: #{e}"
 end

--- a/bin/campfire_export
+++ b/bin/campfire_export
@@ -53,9 +53,13 @@ ensure_config_for(config, 'subdomain',
 ensure_config_for(config, 'api_token',
   "Your Campfire API token (see 'My Info' on your Campfire site)")
 
+export_dir = 'campfire'
+export_dir = config['export_basedir'] unless config['export_basedir'].nil?
+
 begin
-  account = CampfireExport::Account.new(config['subdomain'], 
-                                        config['api_token'])
+  account = CampfireExport::Account.new(config['subdomain'],
+                                        config['api_token'],
+                                        export_dir)
   account.find_timezone
   account.rooms.each do |room|
     room.export(config_date(config, 'start_date'),

--- a/bin/campfire_export
+++ b/bin/campfire_export
@@ -42,7 +42,7 @@ def ensure_config_for(config, key, prompt)
 end
 
 config = {}
-config_file = File.join(ENV['HOME'], '.campfire_export.yaml')
+config_file = ARGV[0] or File.join(ENV['HOME'], '.campfire_export.yaml')
 
 if File.exists?(config_file) and File.readable?(config_file)
   config = YAML.load_file(config_file)  

--- a/lib/campfire_export.rb
+++ b/lib/campfire_export.rb
@@ -55,7 +55,7 @@ module CampfireExport
     # If room or date are defined in the calling object they will be used to
     # build a more accurate directory.
     def export_dir
-      dir = "campfire/#{Account.subdomain}"
+      dir = "#{Account.export_basedir}/#{Account.subdomain}"
       if defined? room:
         dir += "/#{room.name}"
       end
@@ -136,17 +136,20 @@ module CampfireExport
     @subdomain = ""
     @api_token = ""
     @base_url  = ""
+    @export_basedir = ""
     @timezone  = nil
     @user_ids  = []
     
     class << self
-      attr_accessor :subdomain, :api_token, :base_url, :timezone, :user_ids
+      attr_accessor :subdomain, :api_token, :base_url, :export_basedir,
+                    :timezone, :user_ids
     end
     
-    def initialize(subdomain, api_token)
+    def initialize(subdomain, api_token, export_basedir)
       Account.subdomain = subdomain
       Account.api_token = api_token
       Account.base_url  = "https://#{subdomain}.campfirenow.com"
+      Account.export_basedir = export_basedir
     end
 
     def find_timezone

--- a/lib/campfire_export.rb
+++ b/lib/campfire_export.rb
@@ -102,7 +102,8 @@ module CampfireExport
       when :error
         short_error = ["*** Error: #{message}", exception].compact.join(": ")
         $stderr.puts short_error
-        open("campfire/export_errors.txt", 'a') do |log|
+        dir = "#{Account.export_basedir}/#{Account.subdomain}"
+        open("#{dir}/export_errors.txt", 'a') do |log|
           log.write short_error
           unless exception.nil?
             log.write %Q{\n\t#{exception.backtrace.join("\n\t")}}


### PR DESCRIPTION
Updated to:
- export a list of all rooms and a list of all users. Since Campfire doesn't provide a way to fetch all the users in an account, we generate the list based off of which user ids have sent messages.
- take the config file as a command line argument (optional)
- let the user specify the destination of the export (optional) via export_basedir value in the config file
