### PR TITLE
Update campfire_export.gemspec

### DIFF
--- a/campfire_export.gemspec
+++ b/campfire_export.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency "rspec",    "~> 2.6.0"
   s.add_dependency "tzinfo",   "~> 0.3.29"
   s.add_dependency "httparty", "~> 0.7.8"
-  s.add_dependency "nokogiri", "~> 1.4.5"
+  s.add_dependency "nokogiri", "~> 1.5.6"
 
   s.files         = `git ls-files`.split("\n")
   s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")


### PR DESCRIPTION
Update nokogiri to latest version to allow for installing on Ubuntu 12.10. More details [here](http://stackoverflow.com/questions/13085404/installing-nokogiri-v-1-5-0-gem-in-ubuntu-12-10).
